### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Build and Lint
 
 on: [push, pull_request]


### PR DESCRIPTION
Potential fix for [https://github.com/mpatfield/homebridge-easy-mqtt/security/code-scanning/1](https://github.com/mpatfield/homebridge-easy-mqtt/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimal required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code, installs dependencies, lints, builds, and audits dependencies (all read-only operations), the minimal permission required is `contents: read`. This can be set at the workflow level (applies to all jobs) or at the job level (applies only to the specific job). The best practice is to set it at the workflow level unless a job requires different permissions. The change should be made by inserting the following block after the `name:` line and before the `on:` line in `.github/workflows/build.yml`:

```yaml
permissions:
  contents: read
```

No additional methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
