### PR TITLE
Value Transformer Support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Note that setting the this information in the JSON config will override the envi
 
 You will need to make sure to populate the appropriate topics based on the accessory type defined below.
 
-You may define topics using a JSONPath dot notation to assist the parser in finding the right value within the message. See [JSONPaths](#jsonpaths) below for more details.
+You may define topics using a JSONPath dot notation to assist the parser in finding the right value within the message. You can also add a value transformer to alter the incoming or outgoing value. See [Advanced Topic Notation](#advanced-topic-notation) below for more details.
 
 As with topics, you will also need to populate the appropriate values based on the type. Note that while they are defined as strings, they will be auto-converted to the appropriate primitives (e.g. boolean or number) where appropriate.
 
@@ -545,7 +545,9 @@ Each entry should have a topic and a message:
 ]
 ```
 
-## JSONPaths
+## Advanced Topic Notation
+
+### JSONPaths
 
 For some devices, the desired values in the MQTT messages are embedded within a JSON object. For example, here is the MQTT message for my door lock that is received when the door is locked:
 
@@ -609,6 +611,30 @@ As with get topics, you can have an arbitrarily complex chain. So if, for exampl
 then you would use the topic
 
 `zwave/4/security/set$.target.mode.value`
+
+### Value Transformers
+
+There are other situations where the value needs to be adjusted or altered entirely.
+
+For example, you may have an Air Quality Sensor that measures Nitrogen Dioxide in ppm (parts per million) instead of µg/m³ (micrograms per cubic meter) which HomeKit expects. In this case, you need to multiply by the arbitrary number 1883 to get the correct result.
+
+Using the pipe (`|`) notation, you may add a transformer:
+
+`airquality/no2|value * 1883`
+
+This will multiply the value by `1883` to get the desired result.
+
+Note that `value` is a reserved keyword here to indicate the incoming value you'd like to transform.
+
+You can also do the same thing on the publish side to transfer it back to ppm. In this case, you would need to divide by 1883.
+
+`airquality/no2|value / 1883`
+
+### JSONPath + Transformer
+
+You may also combine JSONPath and Transformer notation into a single entity
+
+`airquality$.no2|value * 1883`
 
 ## Custom Characteristics
 

--- a/src/accessory/abstract/common.ts
+++ b/src/accessory/abstract/common.ts
@@ -237,7 +237,7 @@ export abstract class Common<C extends Assertable> {
         bool = false;
         break;
       default:
-        this.log.error(strings.characteristic.unknownValue);
+        this.log.error(strings.characteristic.unknownValue, this.name, `'${value}'`);
         return;
       }
 

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -422,6 +422,8 @@ const en = {
     receivedMessage: 'Received message on %s with topic %s', // host, topic
     reconnectMinutes: 'Will attempt to reconnect to %s in %s minutes…', // host, number
     reconnectSeconds: 'Will attempt to reconnect to %s in %s seconds…', // host, number
+    transformFailed: 'Unable to execute transform:',
+    transformedValue: 'Transforming value from %s to %s', // number, number
   },
 
   onOff: {

--- a/src/model/mqtt.ts
+++ b/src/model/mqtt.ts
@@ -15,51 +15,33 @@ const DELAYS = [5 * SECOND, 10 * SECOND, 30 * SECOND, 2 * MINUTE, 5 * MINUTE];
 
 const DEFAULT_BROKER = 'mqtt://127.0.0.1/';
 
-/**
- * Safely executes a JavaScript expression as a transformer
- * @param expression The JavaScript expression to execute
- * @param value The input value to transform
- * @param log Logger instance for error reporting
- * @returns The transformed value or the original value if transformation fails
- */
-function executeTransformer(transformer: string, value: PrimitiveTypes, log: Log): PrimitiveTypes {
-  try {
-    // Create function with the expression
-    const transformerFunction = new Function('value', `return ${transformer}`);
-    return toPrimitive(transformerFunction(value));
-  } catch (error) {
-    log.error(`Transformer execution failed for expression "${transformer}": ${error}`);
-    return value;
-  }
-}
-
 type MQTTMessageHandler = (topic: string, value: PrimitiveTypes) => void;
 
-type Topic = { base: string, jsonPath: string[], transformer: string | undefined };
+type Topic = { base: string, jsonPath: string[], transformer?: string };
 
 function toTopicObject(rawTopic: string): Topic {
 
-  let base: string;
-  let jsonPath: string[];
+  let base = rawTopic;
+  let jsonPath: string[] = [];
   let transformer: string | undefined;
 
-  const index = rawTopic.indexOf('$');
-  if (index === -1) {
-    base = rawTopic;
-    jsonPath = [];
-  } else {
-    base = rawTopic.slice(0, index);
-    const pathAndTransformers = rawTopic.slice(index).replace(/^\$?\.?/, '');
+  const pipeIndex = rawTopic.indexOf('|');
+  const dollarIndex = rawTopic.indexOf('$.');
 
-    // Check if there are transformers (pipe-separated)
-    const pipeIndex = pathAndTransformers.indexOf('|');
-    if (pipeIndex === -1) {
-      jsonPath = pathAndTransformers.split('.');
-      transformer = undefined;
-    } else {
-      jsonPath = pathAndTransformers.slice(0, pipeIndex).split('.');
-      transformer = pathAndTransformers.slice(pipeIndex + 1).trim();
-    }
+  if (pipeIndex !== -1) {
+    transformer = rawTopic.slice(pipeIndex + 1).trim();
+    base = rawTopic.slice(0, pipeIndex);
+  }
+
+  if (dollarIndex !== -1 && (pipeIndex === -1 || dollarIndex < pipeIndex)) {
+    const jsonPathString = base.slice(dollarIndex + 2);
+    jsonPath = jsonPathString.split('.').filter(p => p.length > 0);
+    base = base.slice(0, dollarIndex);
+  }
+
+  const finalPipeIndex = base.indexOf('|');
+  if (finalPipeIndex !== -1) {
+    base = base.slice(0, finalPipeIndex);
   }
 
   return { base, jsonPath, transformer };
@@ -243,10 +225,8 @@ export class MQTT {
 
     const topic = toTopicObject(rawTopic);
 
-    // Apply transformers in sequence (pipe-style) for outgoing messages
-    let transformedValue = value;
     if (topic.transformer) {
-      transformedValue = executeTransformer(topic.transformer, transformedValue, this.log);
+      value = this.executeTransformer(topic.transformer, value);
     }
 
     let message: string;
@@ -258,7 +238,7 @@ export class MQTT {
       do {
         const pathPart = pathParts.pop()!;
         if (pathParts.length === topic.jsonPath.length - 1) {
-          messageObject[pathPart] = transformedValue;
+          messageObject[pathPart] = value;
         } else {
           messageObject = { [pathPart]: messageObject };
         }
@@ -267,7 +247,7 @@ export class MQTT {
       message = JSON.stringify(messageObject);
 
     } else {
-      message = transformedValue.toString();
+      message = value.toString();
     }
 
     this.client.publish(topic.base, message, this.options);
@@ -311,14 +291,12 @@ export class MQTT {
           value = message;
         }
 
-        // Apply transformers in sequence (pipe-style)
-        let transformedValue = toPrimitive(value);
+        value = toPrimitive(value);
         if (listener.topic.transformer) {
-          transformedValue = executeTransformer(listener.topic.transformer, transformedValue, this.log);
+          value = this.executeTransformer(listener.topic.transformer, value);
         }
 
-        this.log.ifVerbose(strings.mqttClient.receivedMessage, this.host, topic, `\n${message}=>${transformedValue}`);
-        listener.handler(topic, transformedValue);
+        listener.handler(topic, value);
       }
 
     } catch (e) {
@@ -357,5 +335,20 @@ export class MQTT {
       this.isReconnecting = false;
       this.connect();
     }, reconnectDelay);
+  }
+
+  private executeTransformer(transformer: string, value: PrimitiveTypes): PrimitiveTypes {
+    try {
+      const transformerFunction = new Function('value', `const v = JSON.parse(value); return ${transformer.replaceAll('value', 'v')}`);
+      const newValue = toPrimitive(transformerFunction(value));
+
+      this.log.ifVerbose(strings.mqttClient.transformedValue, value, newValue);
+
+      return newValue;
+
+    } catch (error) {
+      this.log.error(strings.mqttClient.transformFailed, `'${transformer}'`, `\n${error}`);
+      return value;
+    }
   }
 }

--- a/src/model/mqtt.ts
+++ b/src/model/mqtt.ts
@@ -15,14 +15,33 @@ const DELAYS = [5 * SECOND, 10 * SECOND, 30 * SECOND, 2 * MINUTE, 5 * MINUTE];
 
 const DEFAULT_BROKER = 'mqtt://127.0.0.1/';
 
+/**
+ * Safely executes a JavaScript expression as a transformer
+ * @param expression The JavaScript expression to execute
+ * @param value The input value to transform
+ * @param log Logger instance for error reporting
+ * @returns The transformed value or the original value if transformation fails
+ */
+function executeTransformer(transformer: string, value: PrimitiveTypes, log: Log): PrimitiveTypes {
+  try {
+    // Create function with the expression
+    const transformerFunction = new Function("value", `return ${transformer}`);
+    return toPrimitive(transformerFunction(value));
+  } catch (error) {
+    log.error(`Transformer execution failed for expression "${transformer}": ${error}`);
+    return value;
+  }
+}
+
 type MQTTMessageHandler = (topic: string, value: PrimitiveTypes) => void;
 
-type Topic = { base: string, jsonPath: string[] };
+type Topic = { base: string, jsonPath: string[], transformer: string | undefined };
 
 function toTopicObject(rawTopic: string): Topic {
 
   let base: string;
   let jsonPath: string[];
+  let transformer: string | undefined;
 
   const index = rawTopic.indexOf('$');
   if (index === -1) {
@@ -30,10 +49,20 @@ function toTopicObject(rawTopic: string): Topic {
     jsonPath = [];
   } else {
     base = rawTopic.slice(0, index);
-    jsonPath = rawTopic.slice(index).replace(/^\$?\.?/, '').split('.');
+    const pathAndTransformers = rawTopic.slice(index).replace(/^\$?\.?/, '');
+
+    // Check if there are transformers (pipe-separated)
+    const pipeIndex = pathAndTransformers.indexOf('|');
+    if (pipeIndex === -1) {
+      jsonPath = pathAndTransformers.split('.');
+      transformer = undefined;
+    } else {
+      jsonPath = pathAndTransformers.slice(0, pipeIndex).split('.');
+      transformer = pathAndTransformers.slice(pipeIndex + 1).trim();
+    }
   }
 
-  return { base: base, jsonPath: jsonPath };
+  return { base, jsonPath, transformer };
 }
 
 class MQTTListener {
@@ -214,6 +243,12 @@ export class MQTT {
 
     const topic = toTopicObject(rawTopic);
 
+    // Apply transformers in sequence (pipe-style) for outgoing messages
+    let transformedValue = value;
+    if (topic.transformer) {
+      transformedValue = executeTransformer(topic.transformer, transformedValue, this.log);
+    }
+
     let message: string;
     if (topic.jsonPath.length) {
 
@@ -223,7 +258,7 @@ export class MQTT {
       do {
         const pathPart = pathParts.pop()!;
         if (pathParts.length === topic.jsonPath.length - 1) {
-          messageObject[pathPart] = value;
+          messageObject[pathPart] = transformedValue;
         } else {
           messageObject = { [pathPart]: messageObject };
         }
@@ -232,7 +267,7 @@ export class MQTT {
       message = JSON.stringify(messageObject);
 
     } else {
-      message = value.toString();
+      message = transformedValue.toString();
     }
 
     this.client.publish(topic.base, message, this.options);
@@ -277,7 +312,13 @@ export class MQTT {
           value = message;
         }
 
-        listener.handler(topic, toPrimitive(value));
+        // Apply transformers in sequence (pipe-style)
+        let transformedValue = toPrimitive(value);
+        if (listener.topic.transformer) {
+          transformedValue = executeTransformer(listener.topic.transformer, transformedValue, this.log);
+        }
+
+        listener.handler(topic, transformedValue);
       }
 
     } catch (e) {

--- a/src/model/mqtt.ts
+++ b/src/model/mqtt.ts
@@ -25,7 +25,7 @@ const DEFAULT_BROKER = 'mqtt://127.0.0.1/';
 function executeTransformer(transformer: string, value: PrimitiveTypes, log: Log): PrimitiveTypes {
   try {
     // Create function with the expression
-    const transformerFunction = new Function("value", `return ${transformer}`);
+    const transformerFunction = new Function('value', `return ${transformer}`);
     return toPrimitive(transformerFunction(value));
   } catch (error) {
     log.error(`Transformer execution failed for expression "${transformer}": ${error}`);

--- a/src/model/mqtt.ts
+++ b/src/model/mqtt.ts
@@ -292,7 +292,6 @@ export class MQTT {
       }
 
       for (const listener of listeners) {
-
         let value;
         if (message.startsWith('{')) {
 
@@ -318,6 +317,7 @@ export class MQTT {
           transformedValue = executeTransformer(listener.topic.transformer, transformedValue, this.log);
         }
 
+        this.log.ifVerbose(strings.mqttClient.receivedMessage, this.host, topic, `\n${message}=>${transformedValue}`);
         listener.handler(topic, transformedValue);
       }
 


### PR DESCRIPTION
- Transform MQTT values using pipe syntax: topic$path|expression
- Added executeTransformer() function with error handling
- Supports both incoming and outgoing message transformations
- Backward compatible with existing topics

**Use cases:**
```
sensor/temperature$.value|value * 9/5 + 32  # Celsius to Fahrenheit
outlet/state$.value|value > 0 ? "ON" : "OFF"    # Number to string
```